### PR TITLE
Clearly state where the extension is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,14 @@ Clone this repo and run `npm install` to install the npm dependencies.
 
 ## Usage
 
-To build the `.vue` files to make them ready for use in Directus, you can run `npm run build`. This will generate everything in the dist folder. To install this interface into Directus, create a new folder in the `/public/extensions/custom/interfaces/` folder called `my-interface` (or any other name) and put the contents of the `dist` folder in that newly created `my-interface` folder. 
+### Building the extension
+
+To build the `.vue` files to make them ready for use in Directus, you can run `npm run build`. This will generate everything in the dist folder.
+
+### Installing the extension into Directus
+
+Remember that that Directus extensions are actually stored in the API codebase. Therefore, in the Directus API:
+
+1. Navigate to the directory `/public/extensions/custom/interfaces/`
+2. Create a folder called `my-interface` (or any other name)
+3. Put the contents of the `dist` folder in that newly created `my-interface` folder


### PR DESCRIPTION
Since the fact of installing the extensions in the API may seem counterintuitive for beginners to Directus, I think it's worth to be a brief and clear statement about it.